### PR TITLE
大佬，发现您的项目引入了commons-io:commons-io@2.2组件，存在安全漏洞，提一个PR，建议升级修复

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.ruoyi</groupId>
@@ -16,7 +15,7 @@
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
         <version>2.5.10</version>
-        <relativePath />
+        <relativePath/>
     </parent>
 
     <properties>
@@ -28,7 +27,7 @@
         <pagehelper.spring.boot.starter.version>1.4.1</pagehelper.spring.boot.starter.version>
         <fastjson.version>1.2.79</fastjson.version>
         <druid.version>1.2.8</druid.version>
-        <commons.io.version>2.11.0</commons.io.version>
+        <commons.io.version>2.7</commons.io.version>
         <commons.fileupload.version>1.4</commons.fileupload.version>
         <commons.collections.version>3.2.2</commons.collections.version>
         <bitwalker.version>1.21</bitwalker.version>


### PR DESCRIPTION
本次提交修复的漏洞信息:
```
漏洞标题：Apache Commons IO路径遍历漏洞
缺陷组件：commons-io:commons-io@2.2
漏洞编号：CVE-2021-29425
漏洞描述：Apache Commons IO是美国阿帕奇基金会（Apache）公司的一个应用程序。可以帮助开发IO功能。
Apache Commons IO 2.2版本至2.6版本存在路径遍历漏洞。该漏洞与FileNameUtils.normalize方法有关。攻击者可以利用该漏洞通过发送错误的输入字符串（例如“//../foo”或“\\..\foo”）获得对父目录中文件的访问权限。
国家漏洞库信息：https://www.cnvd.org.cn/flaw/show/CNVD-2021-30583
影响范围：[0, 2.7)
最小修复版本：2.7
缺陷组件引入路径：com.ruoyi:ruoyi@3.8.1->commons-fileupload:commons-fileupload@1.4->commons-io:commons-io@2.2
```
另外我运行这个项目时，IDE的安全插件提示还有62个漏洞，我不确定升级是否会有兼容性问题。您有空的话可以查看报告修复下哈。感谢感谢。

相关漏洞详细报告：https://mofeisec.com/jr?p=pec21c